### PR TITLE
fix missing numpy/arrayobject.h error

### DIFF
--- a/pyoptflow/setup.py
+++ b/pyoptflow/setup.py
@@ -1,4 +1,4 @@
-
+import numpy
 from distutils.core import setup, Extension
 
 with_brox    = False
@@ -33,7 +33,8 @@ if with_clg == True:
 
 include_dirs = ["/usr/include/optflow", 
                 "/usr/local/include/optflow", 
-                "./pyoptflow/core"]
+                "./pyoptflow/core",
+                numpy.get_include()]
 include_dirs.extend(ext_include_dirs)
 
 library_dirs = ["/usr/lib", 


### PR DESCRIPTION
In case of installing pyoptflow in a virtual python environment, the numpy headers may not be found in usual include locations, which prevents installing pyoptflow. The correct way to address this is by using `numpy.get_include()`, as pointed out here: https://stackoverflow.com/a/35784219

The installation error can be reproduced by making a fresh virtual environment using virtualenv, enabling it, installing the requirements inside the env and then trying to install pyoptflow.

The proposed fix has been tested on a fresh virtualenv.